### PR TITLE
Update to 1.18.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 plugins {
-	id 'fabric-loom' version '0.9-SNAPSHOT'
+	id 'fabric-loom' version '0.10-SNAPSHOT'
 	id 'maven-publish'
 	id 'java'
 	id 'java-library'
 	id 'idea'
 }
 
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -61,8 +61,8 @@ tasks.withType(JavaCompile).configureEach {
 	// If Javadoc is generated, this must be specified in that task too.
 	it.options.encoding = "UTF-8"
 
-	// Minecraft 1.17 (21w19a) upwards uses Java 16.
-	it.options.release = 16
+	// Minecraft 1.18 (1.18-pre2) upwards uses Java 17.
+	it.options.release = 17
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,13 +3,13 @@
 
 # Fabric Properties
 # check these on https://fabricmc.net/use https://modmuss50.me/fabric.html
-	minecraft_version=1.17.1
-	yarn_mappings=1.17.1+build.61
-	loader_version=0.11.7
+	minecraft_version=1.18.1
+	yarn_mappings=1.18.1+build.18
+	loader_version=0.12.12
 
 #Fabric api
-	fabric_version=0.40.1+1.17
+	fabric_version=0.45.2+1.18
 # Mod Properties
-	mod_version = 1.2.3
+	mod_version = 1.3.0
 	maven_group = com.github.legoatoom.connectiblechains
   	archives_base_name = connectiblechains

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/github/legoatoom/connectiblechains/client/ClientInitializer.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/client/ClientInitializer.java
@@ -40,7 +40,6 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.util.hit.EntityHitResult;
-import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.registry.Registry;
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/com/github/legoatoom/connectiblechains/client/render/entity/ChainKnotEntityRenderer.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/client/render/entity/ChainKnotEntityRenderer.java
@@ -17,6 +17,7 @@
 
 package com.github.legoatoom.connectiblechains.client.render.entity;
 
+import com.github.legoatoom.connectiblechains.ConnectibleChains;
 import com.github.legoatoom.connectiblechains.client.ClientInitializer;
 import com.github.legoatoom.connectiblechains.client.render.entity.model.ChainKnotEntityModel;
 import com.github.legoatoom.connectiblechains.enitity.ChainKnotEntity;
@@ -26,10 +27,13 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.render.*;
 import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.client.render.entity.EntityRendererFactory;
+import net.minecraft.client.render.model.BakedModelManager;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.decoration.AbstractDecorationEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.*;
 import net.minecraft.world.LightType;
@@ -39,6 +43,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.github.legoatoom.connectiblechains.util.Helper.drip2;
+import static com.github.legoatoom.connectiblechains.util.Helper.drip2prime;
 
 /**
  * <p>This class renders the chain you see in game. The block around the fence and the chain.
@@ -56,28 +61,14 @@ import static com.github.legoatoom.connectiblechains.util.Helper.drip2;
  */
 @Environment(EnvType.CLIENT)
 public class ChainKnotEntityRenderer extends EntityRenderer<ChainKnotEntity> {
-    private static final Identifier TEXTURE = Helper.identifier("textures/entity/chain_knot.png");
+    private static final Identifier KNOT_TEXTURE = Helper.identifier("textures/entity/chain_knot.png");
+    private static final Identifier CHAIN_TEXTURE = new Identifier("textures/block/chain.png");
     private final ChainKnotEntityModel<ChainKnotEntity> model;
-
+    private final ChainRenderer chainRenderer = new ChainRenderer();
 
     public ChainKnotEntityRenderer(EntityRendererFactory.Context context) {
         super(context);
         this.model = new ChainKnotEntityModel<>(context.getPart(ClientInitializer.CHAIN_KNOT));
-    }
-
-    /**
-     * Draw a pixel with 4 vector locations and the other information.
-     */
-    private static void renderPixel(Vec3f startA, Vec3f startB, Vec3f endA, Vec3f endB,
-                                    VertexConsumer vertexConsumer, Matrix4f matrix4f, int lightPack,
-                                    float R, float G, float B) {
-
-        vertexConsumer.vertex(matrix4f, startA.getX(), startA.getY(), startA.getZ()).color(R, G, B, 1.0F).light(lightPack).next();
-        vertexConsumer.vertex(matrix4f, startA.getX(), startA.getY(), startA.getZ()).color(R, G, B, 1.0F).light(lightPack).next();
-        vertexConsumer.vertex(matrix4f, endA.getX(), endA.getY(), endA.getZ()).color(R, G, B, 1.0F).light(lightPack).next();
-        vertexConsumer.vertex(matrix4f, startB.getX(), startB.getY(), startB.getZ()).color(R, G, B, 1.0F).light(lightPack).next();
-        vertexConsumer.vertex(matrix4f, endB.getX(), endB.getY(), endB.getZ()).color(R, G, B, 1.0F).light(lightPack).next();
-        vertexConsumer.vertex(matrix4f, endB.getX(), endB.getY(), endB.getZ()).color(R, G, B, 1.0F).light(lightPack).next();
     }
 
     @Override
@@ -102,22 +93,51 @@ public class ChainKnotEntityRenderer extends EntityRenderer<ChainKnotEntity> {
     }
 
     public Identifier getTexture(ChainKnotEntity chainKnotEntity) {
-        return TEXTURE;
+        return KNOT_TEXTURE;
     }
 
     @Override
     public void render(ChainKnotEntity chainKnotEntity, float yaw, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light) {
         matrices.push();
-        matrices.scale(-0.9F, -0.9F, 0.9F);
+        Vec3d leashOffset = chainKnotEntity.getLeashPos(tickDelta).subtract(chainKnotEntity.getLerpedPos(tickDelta));
+        matrices.translate(leashOffset.x, leashOffset.y + 6.5/16f, leashOffset.z);
+        matrices.scale(5/6f, 1, 5/6f);
         this.model.setAngles(chainKnotEntity, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F);
-        VertexConsumer vertexConsumer = vertexConsumers.getBuffer(this.model.getLayer(TEXTURE));
+        VertexConsumer vertexConsumer = vertexConsumers.getBuffer(this.model.getLayer(KNOT_TEXTURE));
         this.model.render(matrices, vertexConsumer, light, OverlayTexture.DEFAULT_UV, 1.0F, 1.0F, 1.0F, 1.0F);
         matrices.pop();
         ArrayList<Entity> entities = chainKnotEntity.getHoldingEntities();
         for (Entity entity : entities) {
             this.createChainLine(chainKnotEntity, tickDelta, matrices, vertexConsumers, entity);
+            if(ConnectibleChains.runtimeConfig.doDebugDraw()) {
+                this.drawDebugVector(matrices, chainKnotEntity, entity, vertexConsumers.getBuffer(RenderLayer.LINES));
+            }
+        }
+        if(ConnectibleChains.runtimeConfig.doDebugDraw()) {
+            matrices.push();
+            // F stands for "from"
+            Text holdingCount = new LiteralText("F: " + chainKnotEntity.getHoldingEntities().size());
+            matrices.translate(0, 0.25, 0);
+            this.renderLabelIfPresent(chainKnotEntity, holdingCount, matrices, vertexConsumers, light);
+            matrices.pop();
         }
         super.render(chainKnotEntity, yaw, tickDelta, matrices, vertexConsumers, light);
+    }
+
+    /**
+     * Draws a line fromEntity - toEntity, from green to red.
+     */
+    private void drawDebugVector(MatrixStack matrices, Entity fromEntity, Entity toEntity, VertexConsumer buffer) {
+        if(toEntity == null) return;
+        Matrix4f modelMat = matrices.peek().getPositionMatrix();
+        Vec3d vec = toEntity.getPos().subtract(fromEntity.getPos());
+        Vec3d normal = vec.normalize();
+        buffer.vertex(modelMat, 0, 0, 0)
+                .color(0, 255, 0, 255)
+                .normal((float)normal.x, (float)normal.y, (float)normal.z).next();
+        buffer.vertex(modelMat, (float)vec.x, (float)vec.y, (float)vec.z)
+                .color(255, 0, 0, 255)
+                .normal((float)normal.x, (float)normal.y, (float)normal.z).next();
     }
 
     /**
@@ -133,52 +153,37 @@ public class ChainKnotEntityRenderer extends EntityRenderer<ChainKnotEntity> {
      */
     private void createChainLine(ChainKnotEntity fromEntity, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumerProvider, Entity toEntity) {
         if (toEntity == null) return; // toEntity can be null, this will return the function if it is null.
-        matrices.push(); // We push here to start new I think.
+        matrices.push();
 
-        // Some math that has to do with the direction and yaw of the entity to know where to start and end.
-        double d = MathHelper.lerp(tickDelta * 0.5F, toEntity.getYaw(), toEntity.prevYaw) * 0.017453292F;
-        double e = MathHelper.lerp(tickDelta * 0.5F, toEntity.getPitch(), toEntity.prevPitch) * 0.017453292F;
-        double g = Math.cos(d);
-        double h = Math.sin(d);
-        double i = Math.sin(e);
+        // Don't have to lerp knot position as it can't move
+        // Also lerping the position of an entity that was just created
+        // causes visual bugs because the position is lerped from 0/0/0.
+        Vec3d srcPos = fromEntity.getPos().add(fromEntity.getLeashOffset());
+        Vec3d dstPos;
 
-        // Now we have to know whether we connect to a player or a chain to define the start and end points of the chain.
-        float lerpDistanceZ, lerpDistanceX, lerpDistanceY;
-        if (toEntity instanceof AbstractDecorationEntity) {
-            // If the chain is connected to another chain
-            double toLerpX = MathHelper.lerp(tickDelta, toEntity.prevX, toEntity.getX());
-            double toLerpY = MathHelper.lerp(tickDelta, toEntity.prevY, toEntity.getY());
-            double toLerpZ = MathHelper.lerp(tickDelta, toEntity.prevZ, toEntity.getZ());
-            double fromLerpX = MathHelper.lerp(tickDelta, fromEntity.prevX, fromEntity.getX());
-            double fromLerpY = MathHelper.lerp(tickDelta, fromEntity.prevY, fromEntity.getY());
-            double fromLerpZ = MathHelper.lerp(tickDelta, fromEntity.prevZ, fromEntity.getZ());
-            lerpDistanceX = (float) (toLerpX - fromLerpX);
-            lerpDistanceY = (float) (toLerpY - fromLerpY);
-            lerpDistanceZ = (float) (toLerpZ - fromLerpZ);
+        if(toEntity instanceof AbstractDecorationEntity) {
+            dstPos = toEntity.getPos().add(toEntity.getLeashOffset());
         } else {
-            // If the chain is connected to a player.
-            double j = Math.cos(e);
-            double k = MathHelper.lerp(tickDelta, toEntity.prevX, toEntity.getX()) - g * 0.7D - h * 0.5D * j;
-            double l = MathHelper.lerp(tickDelta, toEntity.prevY
-                    + (double) toEntity.getStandingEyeHeight() * 0.7D, toEntity.getY()
-                    + (double) toEntity.getStandingEyeHeight() * 0.7D) - i * 0.5D - 0.5D;
-            double m = MathHelper.lerp(tickDelta, toEntity.prevZ, toEntity.getZ()) - h * 0.7D + g * 0.5D * j;
-            double o = MathHelper.lerp(tickDelta, fromEntity.prevX, fromEntity.getX());
-            double p = MathHelper.lerp(tickDelta, fromEntity.prevY, fromEntity.getY()) + 0.3F;
-            double q = MathHelper.lerp(tickDelta, fromEntity.prevZ, fromEntity.getZ());
-
-            lerpDistanceX = (float) (k - o);
-            lerpDistanceY = (float) (l - p);
-            lerpDistanceZ = (float) (m - q);
+            dstPos = toEntity.getLeashPos(tickDelta);
         }
-        matrices.translate(0, 0.3F, 0);
 
-        VertexConsumer vertexConsumer = vertexConsumerProvider.getBuffer(RenderLayer.getLeash());
+        // The leash pos offset
+        Vec3d leashOffset = fromEntity.getLeashOffset();
+        matrices.translate(leashOffset.x, leashOffset.y, leashOffset.z);
 
-        //Create offset based on the location. Example that a line that does not travel in the x then the xOffset will be 0.
-        float v = MathHelper.fastInverseSqrt(lerpDistanceX * lerpDistanceX + lerpDistanceZ * lerpDistanceZ) * 0.025F / 2;
-        float xOffset = lerpDistanceZ * v;
-        float zOffset = lerpDistanceX * v;
+        // Some further performance improvements can be made here:
+        // Create a rendering layer that:
+        // - does not have normals
+        // - does not have an overlay
+        // - does not have vertex color
+        // - uses a tri strp instead of quads
+        VertexConsumer buffer = vertexConsumerProvider.getBuffer(RenderLayer.getEntityCutoutNoCull(CHAIN_TEXTURE));
+        if(ConnectibleChains.runtimeConfig.doDebugDraw()) {
+            buffer = vertexConsumerProvider.getBuffer(RenderLayer.getLines());
+        }
+
+        Vec3f offset = Helper.getChainOffset(srcPos, dstPos);
+        matrices.translate(offset.getX(), 0, offset.getZ());
 
         // Now we gather light information for the chain. Since the chain is lighter if there is more light.
         BlockPos blockPosOfStart = new BlockPos(fromEntity.getCameraPosVec(tickDelta));
@@ -188,249 +193,24 @@ public class ChainKnotEntityRenderer extends EntityRenderer<ChainKnotEntity> {
         int skylightLevelOfStart = fromEntity.world.getLightLevel(LightType.SKY, blockPosOfStart);
         int skylightLevelOfEnd = fromEntity.world.getLightLevel(LightType.SKY, blockPosOfEnd);
 
-        float distance = toEntity.distanceTo(fromEntity);
-        Matrix4f matrix4f = matrices.peek().getModel();
+        Vec3d startPos = srcPos.add(offset.getX(), 0, offset.getZ());
+        Vec3d endPos = dstPos.add(-offset.getX(), 0, -offset.getZ());
+        Vec3f chainVec = new Vec3f((float) (endPos.x - startPos.x), (float) (endPos.y - startPos.y), (float) (endPos.z - startPos.z));
 
-        //This number specifies the number of pixels on the chain.
-        chainDrawer(distance, vertexConsumer, matrix4f, lerpDistanceX, lerpDistanceY, lerpDistanceZ, blockLightLevelOfStart, blockLightLevelOfEnd, skylightLevelOfStart, skylightLevelOfEnd, xOffset, zOffset);
+        float angleY = -(float) Math.atan2(chainVec.getZ(), chainVec.getX());
+        matrices.multiply(Quaternion.fromEulerXyz(0, angleY, 0));
+
+        if (toEntity instanceof AbstractDecorationEntity) {
+            ChainRenderer.BakeKey key = new ChainRenderer.BakeKey(fromEntity.getPos(), toEntity.getPos());
+            chainRenderer.renderBaked(buffer, matrices, key, chainVec, blockLightLevelOfStart, blockLightLevelOfEnd, skylightLevelOfStart, skylightLevelOfEnd);
+        } else {
+            chainRenderer.render(buffer, matrices, chainVec, blockLightLevelOfStart, blockLightLevelOfEnd, skylightLevelOfStart, skylightLevelOfEnd);
+        }
+
         matrices.pop();
     }
 
-
-    /**
-     * Fancy math, it deals with the rotation of the x,y,z coordinates based on the direction of the chain. So that
-     * in every direction the pixels look the same size.
-     *
-     */
-    private static float[] rotator(double x, double y, double z) {
-        double x2 = x * x;
-        double z2 = z * z;
-        double zx = Math.sqrt(x2 + z2);
-        double arc1 = Math.atan2(y, zx);
-        double arc2 = Math.atan2(x, z);
-        double d = Math.sin(arc1) * 0.0125F;
-        float y_new = (float) (Math.cos(arc1) * 0.0125F);
-        float z_new = (float) (Math.cos(arc2) * d);
-        float x_new = (float) (Math.sin(arc2) * d);
-        float v = 0.0F;
-        if (zx == 0.0F) {
-            x_new = z_new;
-            v = 1.0F;
-        }
-        return new float[]{x_new, y_new, z_new, v};
+    public ChainRenderer getChainRenderer() {
+        return chainRenderer;
     }
-
-    /**
-     * This method is the big drawer of the chain.
-     */
-    @SuppressWarnings("DuplicatedCode")
-    private void chainDrawer(float distance, VertexConsumer vertexConsumer, Matrix4f matrix4f,
-                             float lerpDistanceX, float lerpDistanceY, float lerpDistanceZ,
-                             int blockLightLevelOfStart, int blockLightLevelOfEnd,
-                             int skylightLevelOfStart, int skylightLevelOfEnd,
-                             float xOffset, float zOffset) {
-
-        /*Can you see the chain here?*/
-        List<Integer> topLineA, middleLineA, bottomLineA, topLineB, middleLineB, bottomLineB;
-        topLineA    = Arrays.asList(   1, 2, 3,       6, 7, 8, 9,         12, 13, 14);
-        middleLineA = Arrays.asList(   1,    3,       6,       9,         12,     14);
-        bottomLineA = Arrays.asList(   1, 2, 3,       6, 7, 8, 9,         12, 13, 14);
-
-        topLineB    = Arrays.asList(0, 1,    3, 4, 5, 6,       9, 10, 11, 12,     14, 15);
-        middleLineB = Arrays.asList(   1,    3,       6,       9,         12,     14    );
-        bottomLineB = Arrays.asList(0, 1,    3, 4, 5, 6,       9, 10, 11, 12,     14, 15);
-
-        int length = (int) Math.floor(distance * 24); //This number specifies the number of pixels on the chain.
-
-        // LightLevel Stuff
-        float s = (float) skylightLevelOfEnd / (length - 1);
-        int t = (int) MathHelper.lerp(s, (float) blockLightLevelOfStart, (float) blockLightLevelOfEnd);
-        int u = (int) MathHelper.lerp(s, (float) skylightLevelOfStart, (float) skylightLevelOfEnd);
-        int pack = LightmapTextureManager.pack(t, u);
-
-        for (int step = 0; step < length; ++step) {
-
-            float startStepFraction = ((float) step / (float) length);
-            float endStepFraction = ((float) (step + 1) / (float) length);
-            float startDrip = (float) drip2(startStepFraction * distance, distance, lerpDistanceY);
-            float endDrip = (float) drip2(endStepFraction * distance, distance, lerpDistanceY);
-            float startRootX = lerpDistanceX * startStepFraction;
-            float startRootZ = lerpDistanceZ * startStepFraction;
-            float endRootX = lerpDistanceX * endStepFraction;
-            float endRootZ = lerpDistanceZ * endStepFraction;
-            float[] rotateStartEnd = rotator(startRootX - endRootX, (startDrip - endDrip), startRootZ - endRootZ);
-            float v1 = (rotateStartEnd[3] != 1.0F) ? 1.0F : -1.0F;
-            float R, G, B;
-
-            float rotate0 = rotateStartEnd[0];
-            float rotate1 = rotateStartEnd[1];
-            float rotate2 = rotateStartEnd[2];
-            // First Line
-            float chainHeight = 0.0125F;
-            if (topLineA.contains(step % 16)) {
-                Vec3f startA, endA, startB, endB;
-                startA = new Vec3f(
-                        startRootX - rotate0 + xOffset,
-                        chainHeight + rotate1 + startDrip,
-                        startRootZ - rotate2 - zOffset
-                );
-                startB = new Vec3f(
-                        startRootX - (rotate0 - xOffset) * 3,
-                        chainHeight + rotate1 * 3 + startDrip,
-                        startRootZ - (rotate2 + zOffset) * 3
-                );
-                endA = new Vec3f(
-                        endRootX - rotate0 + xOffset,
-                        chainHeight + rotate1 + endDrip,
-                        endRootZ - rotate2 - zOffset
-                );
-                endB = new Vec3f(
-                        endRootX - (rotate0 - xOffset) * 3,
-                        chainHeight + rotate1 * 3 + endDrip,
-                        endRootZ - (rotate2 + zOffset) * 3
-                );
-                R = 0.16F;
-                G = 0.17F;
-                B = 0.21F;
-                renderPixel(startA, startB, endA, endB, vertexConsumer, matrix4f, pack, R, G, B);
-            }
-            if (middleLineA.contains(step % 16)) {
-                Vec3f startA, endA, startB, endB;
-                startA = new Vec3f(
-                        startRootX + rotate0 + xOffset,
-                        chainHeight - rotate1 + startDrip,
-                        startRootZ + rotate2 - zOffset
-                );
-                startB = new Vec3f(
-                        startRootX - rotate0 - xOffset,
-                        chainHeight + rotate1 + startDrip,
-                        startRootZ - rotate2 + zOffset
-                );
-                endA = new Vec3f(
-                        endRootX + rotate0 + xOffset,
-                        chainHeight - rotate1 + endDrip,
-                        endRootZ + rotate2 - zOffset
-                );
-                endB = new Vec3f(
-                        endRootX - rotate0 - xOffset,
-                        chainHeight + rotate1 + endDrip,
-                        endRootZ - rotate2 + zOffset
-                );
-                R = 0.12F * 0.7F;
-                G = 0.12F * 0.7F;
-                B = 0.17F * 0.7F;
-                renderPixel(startA, startB, endA, endB, vertexConsumer, matrix4f, pack, R, G, B);
-            }
-            if (bottomLineA.contains(step % 16)) {
-                Vec3f startA, endA, startB, endB;
-                startA = new Vec3f(
-                        startRootX + (rotate0 - xOffset) * 3,
-                        chainHeight - rotate1 * 3 + startDrip,
-                        startRootZ + (rotate2 + zOffset) * 3
-                );
-                startB = new Vec3f(
-                        startRootX + rotate0 - xOffset,
-                        chainHeight - rotate1 + startDrip,
-                        startRootZ + rotate2 + zOffset
-                );
-                endA = new Vec3f(
-                        endRootX + (rotate0 - xOffset) * 3,
-                        chainHeight - rotate1 * 3 + endDrip,
-                        endRootZ + (rotate2 + zOffset) * 3
-                );
-                endB = new Vec3f(
-                        endRootX + rotate0 - xOffset,
-                        chainHeight - rotate1 + endDrip,
-                        endRootZ + rotate2 + zOffset
-                );
-                R = 0.16F;
-                G = 0.17F;
-                B = 0.21F;
-                renderPixel(startA, startB, endA, endB, vertexConsumer, matrix4f, pack, R, G, B);
-            }
-            // Second Line
-            if (topLineB.contains(step % 16)) {
-                Vec3f startA, endA, startB, endB;
-                startA = new Vec3f(
-                        startRootX - (rotate0 * v1) - xOffset,
-                        chainHeight + rotate1 + startDrip,
-                        startRootZ - rotate2 + zOffset
-                );
-                startB = new Vec3f(
-                        startRootX - ((rotate0 * v1) + xOffset) * 3,
-                        chainHeight + rotate1 * 3 + startDrip,
-                        startRootZ - (rotate2 - zOffset) * 3
-                );
-                endA = new Vec3f(
-                        endRootX - (rotate0 * v1) - xOffset,
-                        chainHeight + rotate1 + endDrip,
-                        endRootZ - rotate2 + zOffset
-                );
-                endB = new Vec3f(
-                        endRootX - ((rotate0 * v1) + xOffset) * 3,
-                        chainHeight + rotate1 * 3 + endDrip,
-                        endRootZ - (rotate2 - zOffset) * 3
-                );
-                R = 0.16F * 0.8F;
-                G = 0.17F * 0.8F;
-                B = 0.21F * 0.8F;
-                renderPixel(startA, startB, endA, endB, vertexConsumer, matrix4f, pack, R, G, B);
-            }
-            if (middleLineB.contains(step % 16)) {
-                Vec3f startA, endA, startB, endB;
-                startA = new Vec3f(
-                        startRootX + (rotate0 * v1) - xOffset,
-                        chainHeight - rotate1 + startDrip,
-                        startRootZ + rotate2 + zOffset
-                );
-                startB = new Vec3f(
-                        startRootX - (rotate0 * v1) + xOffset,
-                        chainHeight + rotate1 + startDrip,
-                        startRootZ - rotate2 - zOffset
-                );
-                endA = new Vec3f(
-                        endRootX + (rotate0 * v1) - xOffset,
-                        chainHeight - rotate1 + endDrip,
-                        endRootZ + rotate2 + zOffset
-                );
-                endB = new Vec3f(
-                        endRootX - (rotate0 * v1) + xOffset,
-                        chainHeight + rotate1 + endDrip,
-                        endRootZ - rotate2 - zOffset
-                );
-                R = 0.12F;
-                G = 0.12F;
-                B = 0.17F;
-                renderPixel(startA, startB, endA, endB, vertexConsumer, matrix4f, pack, R, G, B);
-            }
-            if (bottomLineB.contains(step % 16)) {
-                Vec3f startA, endA, startB, endB;
-                startA = new Vec3f(
-                        startRootX + ((rotate0 * v1) + xOffset) * 3,
-                        chainHeight - rotate1 * 3 + startDrip,
-                        startRootZ + (rotate2 - zOffset) * 3
-                );
-                startB = new Vec3f(
-                        startRootX + (rotate0 * v1) + xOffset,
-                        chainHeight - rotate1 + startDrip,
-                        startRootZ + rotate2 - zOffset
-                );
-                endA = new Vec3f(
-                        endRootX + ((rotate0 * v1) + xOffset) * 3,
-                        chainHeight - rotate1 * 3 + endDrip,
-                        endRootZ + (rotate2 - zOffset) * 3
-                );
-                endB = new Vec3f(
-                        endRootX + (rotate0 * v1) + xOffset,
-                        chainHeight - rotate1 + endDrip,
-                        endRootZ + rotate2 - zOffset
-                );
-                R = 0.16F * 0.8F;
-                G = 0.17F * 0.8F;
-                B = 0.21F * 0.8F;
-                renderPixel(startA, startB, endA, endB, vertexConsumer, matrix4f, pack, R, G, B);
-            }
-        }
-    }
-
 }

--- a/src/main/java/com/github/legoatoom/connectiblechains/client/render/entity/ChainKnotEntityRenderer.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/client/render/entity/ChainKnotEntityRenderer.java
@@ -27,7 +27,6 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.render.*;
 import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.client.render.entity.EntityRendererFactory;
-import net.minecraft.client.render.model.BakedModelManager;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.decoration.AbstractDecorationEntity;
@@ -39,11 +38,6 @@ import net.minecraft.util.math.*;
 import net.minecraft.world.LightType;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static com.github.legoatoom.connectiblechains.util.Helper.drip2;
-import static com.github.legoatoom.connectiblechains.util.Helper.drip2prime;
 
 /**
  * <p>This class renders the chain you see in game. The block around the fence and the chain.

--- a/src/main/java/com/github/legoatoom/connectiblechains/client/render/entity/ChainModel.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/client/render/entity/ChainModel.java
@@ -13,79 +13,83 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ChainModel {
-    private final List<Float> vertices;
-    private final List<Float> uvs;
-    private int size;
+    private final float[] vertices;
+    private final float[] uvs;
 
-    public ChainModel(int initialCapacity) {
-        vertices = new ArrayList<>(initialCapacity*3);
-        uvs = new ArrayList<>(initialCapacity*2);
+    public ChainModel(float[] vertices, float[] uvs) {
+        this.vertices = vertices;
+        this.uvs = uvs;
     }
 
-    public ChainModel vertex(Vec3f v) {
-        vertices.add(v.getX());
-        vertices.add(v.getY());
-        vertices.add(v.getZ());
-        return this;
+    public void render(VertexConsumer buffer, MatrixStack matrices, int bLight0, int bLight1, int sLight0, int sLight1) {
+        Matrix4f modelMatrix = matrices.peek().getPositionMatrix();
+        Matrix3f normalMatrix = matrices.peek().getNormalMatrix();
+        int count = vertices.length / 3;
+        for (int i = 0; i < count; i++) {
+            // divide by 2 because chain has 2 face sets
+            @SuppressWarnings({"IntegerDivisionInFloatingPointContext"})
+            float f = (i % (count/2)) / (float) (count/2);
+            int blockLight = (int) MathHelper.lerp(f, (float) bLight0, (float) bLight1);
+            int skyLight = (int) MathHelper.lerp(f, (float) sLight0, (float) sLight1);
+            int light = LightmapTextureManager.pack(blockLight, skyLight);
+            buffer
+                    .vertex(modelMatrix, vertices[i*3], vertices[i*3+1] , vertices[i*3+2])
+                    .color(255, 255, 255, 255)
+                    .texture(uvs[i*2], uvs[i*2+1])
+                    .overlay(OverlayTexture.DEFAULT_UV)
+                    .light(light)
+                    .normal(normalMatrix, 0, 1, 0)
+                    .next();
+        }
     }
 
-    public ChainModel uv(float u, float v) {
-        uvs.add(u);
-        uvs.add(v);
-        return this;
+    public static Builder builder(int initialCapacity) {
+        return new Builder(initialCapacity);
     }
 
-    public void next() {
-        size++;
-    }
+    public static class Builder {
+        private final List<Float> vertices;
+        private final List<Float> uvs;
+        private int size;
 
-    public BakedChainModel bake() {
-        if(vertices.size() != size*3) throw new AssertionError("Wrong count of vertices");
-        if(uvs.size() != size*2) throw new AssertionError("Wrong count of uvs");
-
-        return new BakedChainModel(toFloatArray(vertices), toFloatArray(uvs));
-    }
-
-    private float[] toFloatArray(List<Float> floats) {
-        float[] array = new float[floats.size()];
-        int i = 0;
-
-        for (float f : floats) {
-            array[i++] = f;
+        public Builder(int initialCapacity) {
+            vertices = new ArrayList<>(initialCapacity*3);
+            uvs = new ArrayList<>(initialCapacity*2);
         }
 
-        return array;
-    }
-
-    public static class BakedChainModel {
-        private final float[] vertices;
-        private final float[] uvs;
-
-        public BakedChainModel(float[] vertices, float[] uvs) {
-            this.vertices = vertices;
-            this.uvs = uvs;
+        public Builder vertex(Vec3f v) {
+            vertices.add(v.getX());
+            vertices.add(v.getY());
+            vertices.add(v.getZ());
+            return this;
         }
 
-        public void render(VertexConsumer buffer, MatrixStack matrices, int bLight0, int bLight1, int sLight0, int sLight1) {
-            Matrix4f modelMatrix = matrices.peek().getPositionMatrix();
-            Matrix3f normalMatrix = matrices.peek().getNormalMatrix();
-            int count = vertices.length / 3;
-            for (int i = 0; i < count; i++) {
-                // divide by 2 because chain has 2 face sets
-                @SuppressWarnings({"IntegerDivisionInFloatingPointContext"})
-                float f = (i % (count/2)) / (float) (count/2);
-                int blockLight = (int) MathHelper.lerp(f, (float) bLight0, (float) bLight1);
-                int skyLight = (int) MathHelper.lerp(f, (float) sLight0, (float) sLight1);
-                int light = LightmapTextureManager.pack(blockLight, skyLight);
-                buffer
-                        .vertex(modelMatrix, vertices[i*3], vertices[i*3+1] , vertices[i*3+2])
-                        .color(255, 255, 255, 255)
-                        .texture(uvs[i*2], uvs[i*2+1])
-                        .overlay(OverlayTexture.DEFAULT_UV)
-                        .light(light)
-                        .normal(normalMatrix, 0, 1, 0)
-                        .next();
+        public Builder uv(float u, float v) {
+            uvs.add(u);
+            uvs.add(v);
+            return this;
+        }
+
+        public void next() {
+            size++;
+        }
+
+        public ChainModel build() {
+            if(vertices.size() != size*3) throw new AssertionError("Wrong count of vertices");
+            if(uvs.size() != size*2) throw new AssertionError("Wrong count of uvs");
+
+            return new ChainModel(toFloatArray(vertices), toFloatArray(uvs));
+        }
+
+        private float[] toFloatArray(List<Float> floats) {
+            float[] array = new float[floats.size()];
+            int i = 0;
+
+            for (float f : floats) {
+                array[i++] = f;
             }
+
+            return array;
         }
     }
 }

--- a/src/main/java/com/github/legoatoom/connectiblechains/client/render/entity/ChainModel.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/client/render/entity/ChainModel.java
@@ -1,0 +1,91 @@
+package com.github.legoatoom.connectiblechains.client.render.entity;
+
+import net.minecraft.client.render.LightmapTextureManager;
+import net.minecraft.client.render.OverlayTexture;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Matrix3f;
+import net.minecraft.util.math.Matrix4f;
+import net.minecraft.util.math.Vec3f;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChainModel {
+    private final List<Float> vertices;
+    private final List<Float> uvs;
+    private int size;
+
+    public ChainModel(int initialCapacity) {
+        vertices = new ArrayList<>(initialCapacity*3);
+        uvs = new ArrayList<>(initialCapacity*2);
+    }
+
+    public ChainModel vertex(Vec3f v) {
+        vertices.add(v.getX());
+        vertices.add(v.getY());
+        vertices.add(v.getZ());
+        return this;
+    }
+
+    public ChainModel uv(float u, float v) {
+        uvs.add(u);
+        uvs.add(v);
+        return this;
+    }
+
+    public void next() {
+        size++;
+    }
+
+    public BakedChainModel bake() {
+        if(vertices.size() != size*3) throw new AssertionError("Wrong count of vertices");
+        if(uvs.size() != size*2) throw new AssertionError("Wrong count of uvs");
+
+        return new BakedChainModel(toFloatArray(vertices), toFloatArray(uvs));
+    }
+
+    private float[] toFloatArray(List<Float> floats) {
+        float[] array = new float[floats.size()];
+        int i = 0;
+
+        for (float f : floats) {
+            array[i++] = f;
+        }
+
+        return array;
+    }
+
+    public static class BakedChainModel {
+        private final float[] vertices;
+        private final float[] uvs;
+
+        public BakedChainModel(float[] vertices, float[] uvs) {
+            this.vertices = vertices;
+            this.uvs = uvs;
+        }
+
+        public void render(VertexConsumer buffer, MatrixStack matrices, int bLight0, int bLight1, int sLight0, int sLight1) {
+            Matrix4f modelMatrix = matrices.peek().getPositionMatrix();
+            Matrix3f normalMatrix = matrices.peek().getNormalMatrix();
+            int count = vertices.length / 3;
+            for (int i = 0; i < count; i++) {
+                // divide by 2 because chain has 2 face sets
+                @SuppressWarnings({"IntegerDivisionInFloatingPointContext"})
+                float f = (i % (count/2)) / (float) (count/2);
+                int blockLight = (int) MathHelper.lerp(f, (float) bLight0, (float) bLight1);
+                int skyLight = (int) MathHelper.lerp(f, (float) sLight0, (float) sLight1);
+                int light = LightmapTextureManager.pack(blockLight, skyLight);
+                buffer
+                        .vertex(modelMatrix, vertices[i*3], vertices[i*3+1] , vertices[i*3+2])
+                        .color(255, 255, 255, 255)
+                        .texture(uvs[i*2], uvs[i*2+1])
+                        .overlay(OverlayTexture.DEFAULT_UV)
+                        .light(light)
+                        .normal(normalMatrix, 0, 1, 0)
+                        .next();
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/legoatoom/connectiblechains/client/render/entity/ChainRenderer.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/client/render/entity/ChainRenderer.java
@@ -1,0 +1,225 @@
+package com.github.legoatoom.connectiblechains.client.render.entity;
+
+import com.github.legoatoom.connectiblechains.ConnectibleChains;
+import com.github.legoatoom.connectiblechains.util.Helper;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.math.*;
+
+import static com.github.legoatoom.connectiblechains.util.Helper.drip2;
+import static com.github.legoatoom.connectiblechains.util.Helper.drip2prime;
+
+public class ChainRenderer {
+    private final Object2ObjectOpenHashMap<BakeKey, ChainModel.BakedChainModel> models = new Object2ObjectOpenHashMap<>(256);
+    private static final float CHAIN_SCALE = 1f;
+    private static final float CHAIN_SIZE = CHAIN_SCALE * 3/16f;
+    private static final int MAX_SEGMENTS = 2048;
+
+    public static class BakeKey {
+        private final int hash;
+        public BakeKey(Vec3d srcPos, Vec3d dstPos) {
+            float dY = (float) (srcPos.y - dstPos.y);
+            float dXZ = Helper.distanceBetween(
+                    new Vec3f((float) srcPos.x, 0, (float) srcPos.z),
+                    new Vec3f((float) dstPos.x, 0, (float) dstPos.z));
+
+            int hash = Float.floatToIntBits(dY);
+            hash = 31 * hash + Float.floatToIntBits(dXZ);
+            this.hash = hash;
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            BakeKey bakeKey = (BakeKey) o;
+
+            return hash == bakeKey.hash;
+        }
+    }
+
+    public void renderBaked(VertexConsumer buffer, MatrixStack matrices, BakeKey key, Vec3f chainVec, int blockLight0, int blockLight1, int skyLight0, int skyLight1) {
+        ChainModel.BakedChainModel model;
+        if(models.containsKey(key)) {
+            model = models.get(key);
+        } else {
+            model = bakeModel(chainVec);
+            models.put(key, model);
+        }
+        model.render(buffer, matrices, blockLight0, blockLight1, skyLight0, skyLight1);
+    }
+
+    public void render(VertexConsumer buffer, MatrixStack matrices, Vec3f chainVec, int blockLight0, int blockLight1, int skyLight0, int skyLight1) {
+        ChainModel.BakedChainModel model = bakeModel(chainVec);
+        model.render(buffer, matrices, blockLight0, blockLight1, skyLight0, skyLight1);
+    }
+
+    private ChainModel.BakedChainModel bakeModel(Vec3f chainVec) {
+        float desiredSegmentLength = 1f / ConnectibleChains.runtimeConfig.getQuality();
+        int initialCapacity = (int) (2f * Helper.lengthOf(chainVec) / desiredSegmentLength);
+        ChainModel model = new ChainModel(initialCapacity);
+
+        if(chainVec.getX() == 0 && chainVec.getZ() == 0) {
+            buildFaceVertical(model, chainVec, 45, 0);
+            buildFaceVertical(model, chainVec, -45, 3);
+        } else {
+            buildFace(model, chainVec, 45, 0);
+            buildFace(model, chainVec, -45, 3);
+        }
+
+        return model.bake();
+    }
+
+    private void buildFaceVertical(ChainModel model, Vec3f v, float angle, int uvu) {
+        float actualSegmentLength = 1f / ConnectibleChains.runtimeConfig.getQuality();
+        Vec3f normal = new Vec3f((float)Math.cos(Math.toRadians(angle)), 0, (float)Math.sin(Math.toRadians(angle)));
+        normal.scale(CHAIN_SIZE);
+
+        Vec3f vert00 = new Vec3f(-normal.getX()/2, 0, -normal.getZ()/2), vert01 = vert00.copy();
+        vert01.add(normal);
+        Vec3f vert10 = new Vec3f(-normal.getX()/2, 0, -normal.getZ()/2), vert11 = vert10.copy();
+        vert11.add(normal);
+
+        float uvv0 = 0, uvv1 = 0;
+        boolean lastIter_ = false;
+        for (int segment = 0; segment < MAX_SEGMENTS; segment++) {
+            if(vert00.getY() + actualSegmentLength >= v.getY()) {
+                lastIter_ = true;
+                actualSegmentLength = v.getY() - vert00.getY();
+            }
+
+            vert10.add(0, actualSegmentLength, 0);
+            vert11.add(0, actualSegmentLength, 0);
+
+            uvv1 += actualSegmentLength / CHAIN_SCALE;
+
+            model.vertex(vert00).uv(uvu/16f, uvv0).next();
+            model.vertex(vert01).uv((uvu+3)/16f, uvv0).next();
+            model.vertex(vert11).uv((uvu+3)/16f, uvv1).next();
+            model.vertex(vert10).uv(uvu/16f, uvv1).next();
+
+            if(lastIter_) break;
+
+            uvv0 = uvv1;
+
+            vert00.set(vert10);
+            vert01.set(vert11);
+        }
+    }
+
+    private void buildFace(ChainModel model, Vec3f v, float angle, int uvu) {
+        float actualSegmentLength, desiredSegmentLength = 1f / ConnectibleChains.runtimeConfig.getQuality();
+        float distance = Helper.lengthOf(v), distanceXZ = (float) Math.sqrt(v.getX()*v.getX() + v.getZ()*v.getZ());
+        // Original code used total distance between start and end instead of horizontal distance
+        // That changed the look of chains when there was a big height difference, but it looks better.
+        float wrongDistanceFactor = distance/distanceXZ;
+
+        Vec3f vert00 = new Vec3f(), vert01 = new Vec3f(), vert11 = new Vec3f(), vert10 = new Vec3f();
+        Vec3f normal = new Vec3f(), rotAxis = new Vec3f();
+
+        float uvv0, uvv1 = 0, gradient, x, y;
+        Vec3f point0 = new Vec3f(), point1 = new Vec3f();
+        Quaternion rotator;
+
+        // All of this setup can probably go, but I can't figure out
+        // how to integrate it into the loop :shrug:
+        point0.set(0, (float) drip2(0, distance, v.getY()), 0);
+        gradient = (float) drip2prime(0, distance, v.getY());
+        normal.set(-gradient, Math.abs(distanceXZ / distance), 0);
+        normal.normalize();
+
+        x = estimateDeltaX(desiredSegmentLength, gradient);
+        gradient = (float) drip2prime(x*wrongDistanceFactor, distance, v.getY());
+        y = (float) drip2(x*wrongDistanceFactor, distance, v.getY());
+        point1.set(x, y, 0);
+
+        rotAxis.set(point1.getX() - point0.getX(), point1.getY() - point0.getY(), point1.getZ() - point0.getZ());
+        rotAxis.normalize();
+        rotator = rotAxis.getDegreesQuaternion(angle);
+
+        normal.rotate(rotator);
+        normal.scale(CHAIN_SIZE);
+        vert10.set(point0.getX() - normal.getX()/2, point0.getY() - normal.getY()/2, point0.getZ() - normal.getZ()/2);
+        vert11.set(vert10);
+        vert11.add(normal);
+
+        actualSegmentLength = Helper.distanceBetween(point0, point1);
+
+        boolean lastIter_ = false;
+        for (int segment = 0; segment < MAX_SEGMENTS; segment++) {
+            rotAxis.set(point1.getX() - point0.getX(), point1.getY() - point0.getY(), point1.getZ() - point0.getZ());
+            rotAxis.normalize();
+            rotator = rotAxis.getDegreesQuaternion(angle);
+
+            // This normal is orthogonal to the face normal
+            normal.set(-gradient, Math.abs(distanceXZ / distance), 0);
+            normal.normalize();
+            normal.rotate(rotator);
+            normal.scale(CHAIN_SIZE);
+
+            vert00.set(vert10);
+            vert01.set(vert11);
+
+            vert10.set(point1.getX() - normal.getX()/2, point1.getY() - normal.getY()/2, point1.getZ() - normal.getZ()/2);
+            vert11.set(vert10);
+            vert11.add(normal);
+
+            uvv0 = uvv1;
+            uvv1 = uvv0 + actualSegmentLength / CHAIN_SCALE;
+
+            model.vertex(vert00).uv(uvu/16f, uvv0).next();
+            model.vertex(vert01).uv((uvu+3)/16f, uvv0).next();
+            model.vertex(vert11).uv((uvu+3)/16f, uvv1).next();
+            model.vertex(vert10).uv(uvu/16f, uvv1).next();
+
+            if(lastIter_) break;
+
+            point0.set(point1);
+
+            x += estimateDeltaX(desiredSegmentLength, gradient);
+            if(x >= distanceXZ) {
+                lastIter_ = true;
+                x = distanceXZ;
+            }
+
+            gradient = (float) drip2prime(x*wrongDistanceFactor, distance, v.getY());
+            y = (float) drip2(x*wrongDistanceFactor, distance, v.getY());
+            point1.set(x, y, 0);
+
+            actualSegmentLength = Helper.distanceBetween(point0, point1);
+        }
+    }
+
+    /**
+     * Estimate Δx based on current gradient to get segments with equal length
+     * k ... Gradient
+     * T ... Tangent
+     * s ... Segment Length
+     *
+     * T = (1, k)
+     *
+     * Δx = (s * T / |T|).x
+     * Δx = s * T.x / |T|
+     * Δx = s * 1 / |T|
+     * Δx = s / |T|
+     * Δx = s / √(1^2 + k^2)
+     * Δx = s / √(1 + k^2)
+     * @param s the desired segment length
+     * @param k the gradient
+     * @return Δx
+     */
+    private float estimateDeltaX(float s, float k) {
+        return (float) (s / Math.sqrt(1 + k*k));
+    }
+
+    public void purge() {
+        models.clear();
+    }
+}

--- a/src/main/java/com/github/legoatoom/connectiblechains/config/ModConfig.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/config/ModConfig.java
@@ -1,18 +1,32 @@
 package com.github.legoatoom.connectiblechains.config;
 
 import com.github.legoatoom.connectiblechains.ConnectibleChains;
+import com.github.legoatoom.connectiblechains.util.NetworkingPackages;
+import io.netty.buffer.Unpooled;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
 import me.shedaniel.autoconfig.annotation.ConfigEntry;
+import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
 
 @Config(name = ConnectibleChains.MODID)
 public class ModConfig implements ConfigData {
+    @ConfigEntry.Gui.Excluded
+    private static final transient boolean IS_DEBUG_ENV = FabricLoader.getInstance().isDevelopmentEnvironment();
 
     @ConfigEntry.Gui.Tooltip(count = 3)
     private float chainHangAmount = 9.0F;
     @ConfigEntry.BoundedDiscrete(max = 32)
     @ConfigEntry.Gui.Tooltip(count = 3)
     private int maxChainRange = 7;
+    @ConfigEntry.BoundedDiscrete(min = 1, max = 8)
+    @ConfigEntry.Gui.Tooltip()
+    private int quality = 4;
 
     public float getChainHangAmount() {
         return chainHangAmount;
@@ -30,5 +44,45 @@ public class ModConfig implements ConfigData {
     @SuppressWarnings("unused")
     public void setMaxChainRange(int maxChainRange) {
         this.maxChainRange = maxChainRange;
+    }
+
+    public boolean doDebugDraw() {
+        return IS_DEBUG_ENV && MinecraftClient.getInstance().options.debugEnabled;
+    }
+
+    @SuppressWarnings("unused")
+    public void setQuality(int quality) {
+        this.quality = quality;
+    }
+
+    public int getQuality() {
+        return quality;
+    }
+
+    public void syncToClients(MinecraftServer server) {
+        for (ServerPlayerEntity player : PlayerLookup.all(server)) {
+            syncToClient(player);
+        }
+    }
+
+    public void syncToClient(ServerPlayerEntity player) {
+        ServerPlayNetworking.send(player, NetworkingPackages.S2C_CONFIG_SYNC_PACKET, this.writePacket());
+    }
+
+    public PacketByteBuf writePacket() {
+        PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
+        buf.writeFloat(chainHangAmount);
+        return buf;
+    }
+
+    public void readPacket(PacketByteBuf buf) {
+        this.chainHangAmount = buf.readFloat();
+    }
+
+    public ModConfig copyFrom(ModConfig config) {
+        this.chainHangAmount = config.chainHangAmount;
+        this.maxChainRange = config.maxChainRange;
+        this.quality = config.quality;
+        return this;
     }
 }

--- a/src/main/java/com/github/legoatoom/connectiblechains/enitity/ChainCollisionEntity.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/enitity/ChainCollisionEntity.java
@@ -66,8 +66,7 @@ public class ChainCollisionEntity extends Entity {
         this(ModEntityTypes.CHAIN_COLLISION, world);
         this.startOwnerId = startOwnerId;
         this.endOwnerId = endOwnerId;
-        this.setPos(x, y, z);
-        this.setBoundingBox(new Box(x, y, z, x, y, z).expand(.01d, 0, .01d));
+        this.setPosition(x, y, z);
     }
 
     @Override

--- a/src/main/java/com/github/legoatoom/connectiblechains/enitity/ChainCollisionEntity.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/enitity/ChainCollisionEntity.java
@@ -33,7 +33,6 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.Packet;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.sound.SoundEvents;
-import net.minecraft.util.math.Box;
 import net.minecraft.world.World;
 
 import java.util.function.Function;

--- a/src/main/java/com/github/legoatoom/connectiblechains/enitity/ChainKnotEntity.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/enitity/ChainKnotEntity.java
@@ -63,12 +63,7 @@ import java.util.stream.Stream;
  * @author legoatoom
  */
 public class ChainKnotEntity extends AbstractDecorationEntity {
-
-    /**
-     * The max range of the chain.
-     */
-    private static final double MAX_RANGE = ConnectibleChains.config.getMaxChainRange();
-
+    
     /**
      * The distance when it is visible.
      */
@@ -109,8 +104,6 @@ public class ChainKnotEntity extends AbstractDecorationEntity {
     public ChainKnotEntity(World world, BlockPos pos) {
         super(ModEntityTypes.CHAIN_KNOT, world, pos);
         this.setPosition((double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D, (double) pos.getZ() + 0.5D);
-        this.setBoundingBox(new Box(this.getX() - 0.1875D, this.getY() - 0.25D + 0.125D, this.getZ() - 0.1875D, this.getX() + 0.1875D, this.getY() + 0.25D + 0.125D, this.getZ() + 0.1875D));
-//        this.teleporting = true;
         this.COLLISION_STORAGE = new HashMap<>();
     }
 
@@ -131,8 +124,8 @@ public class ChainKnotEntity extends AbstractDecorationEntity {
         double j = pos.getY();
         double k = pos.getZ();
         List<ChainKnotEntity> list = world.getNonSpectatingEntities(ChainKnotEntity.class,
-                new Box(i - MAX_RANGE, j - MAX_RANGE, k - MAX_RANGE,
-                        i + MAX_RANGE, j + MAX_RANGE, k + MAX_RANGE));
+                new Box(i - getMaxRange(), j - getMaxRange(), k - getMaxRange(),
+                        i + getMaxRange(), j + getMaxRange(), k + getMaxRange()));
 
         for (ChainKnotEntity otherKnots : list) {
             if (otherKnots.getHoldingEntities().contains(playerEntity)) {
@@ -153,6 +146,13 @@ public class ChainKnotEntity extends AbstractDecorationEntity {
     }
 
     /**
+     * The max range of the chain.
+     */
+    public static double getMaxRange() {
+        return ConnectibleChains.runtimeConfig.getMaxChainRange();
+    }
+
+    /**
      * This entity does not want to set a facing.
      */
     public void setFacing(Direction facing) {
@@ -163,7 +163,9 @@ public class ChainKnotEntity extends AbstractDecorationEntity {
      */
     protected void updateAttachmentPosition() {
         this.setPos((double) this.attachmentPos.getX() + 0.5D, (double) this.attachmentPos.getY() + 0.5D, (double) this.attachmentPos.getZ() + 0.5D);
-        this.setBoundingBox(new Box(this.getX() - 0.1875D, this.getY() - 0.25D + 0.125D, this.getZ() - 0.1875D, this.getX() + 0.1875D, this.getY() + 0.25D + 0.125D, this.getZ() + 0.1875D));
+        double w = this.getType().getWidth() / 2.0;
+        double h = this.getType().getHeight();
+        this.setBoundingBox(new Box(this.getX() - w, this.getY(), this.getZ() - w, this.getX() + w, this.getY() + h, this.getZ() + w));
     }
 
     /**
@@ -174,24 +176,25 @@ public class ChainKnotEntity extends AbstractDecorationEntity {
      */
     @Override
     public void tick() {
-        if (!this.world.isClient) {
-            if (this.getY() < -64.0D) {
-                this.tickInVoid();
-            }
-            this.updateChains();
+        if (this.world.isClient) {
+            return;
+        }
+        if (this.getY() < -64.0D) {
+            this.tickInVoid();
+        }
+        this.updateChains();
 
-            if (this.obstructionCheckCounter++ == 100) {
-                this.obstructionCheckCounter = 0;
-                if (!isRemoved() && !this.canStayAttached()) {
-                    ArrayList<Entity> list = this.getHoldingEntities();
-                    for (Entity entity : list) {
-                        if (entity instanceof ChainKnotEntity) {
-                            damageLink(false, (ChainKnotEntity) entity);
-                        }
+        if (this.obstructionCheckCounter++ == 100) {
+            this.obstructionCheckCounter = 0;
+            if (!isRemoved() && !this.canStayAttached()) {
+                ArrayList<Entity> list = this.getHoldingEntities();
+                for (Entity entity : list) {
+                    if (entity instanceof ChainKnotEntity) {
+                        damageLink(false, (ChainKnotEntity) entity);
                     }
-                    this.remove(RemovalReason.KILLED);
-                    this.onBreak(null);
                 }
+                this.remove(RemovalReason.KILLED);
+                this.onBreak(null);
             }
         }
     }
@@ -237,10 +240,10 @@ public class ChainKnotEntity extends AbstractDecorationEntity {
             if (source.getSource() instanceof PersistentProjectileEntity) {
                 return false;
             }
-            if (sourceEntity instanceof PlayerEntity) {
+            if (sourceEntity instanceof PlayerEntity player) {
                 boolean isCreative = ((PlayerEntity) sourceEntity).isCreative();
-                if (!((PlayerEntity) sourceEntity).getMainHandStack().isEmpty()
-                        && FabricToolTags.SHEARS.contains(((PlayerEntity) sourceEntity).getMainHandStack().getItem())) {
+                if (!player.getMainHandStack().isEmpty()
+                        && FabricToolTags.SHEARS.contains(player.getMainHandStack().getItem())) {
                     ArrayList<Entity> list = this.getHoldingEntities();
                     for (Entity entity : list) {
                         if (entity instanceof ChainKnotEntity) {
@@ -326,7 +329,7 @@ public class ChainKnotEntity extends AbstractDecorationEntity {
 
     /**
      * This method will call {@link #deserializeChainTag(NbtCompound)} if the {@link #chainTags} has any tags.
-     * It will also break all connections that are larger than the {@link #MAX_RANGE}
+     * It will also break all connections that are larger than the {@link #getMaxRange()}
      */
     private void updateChains() {
         if (chainTags != null) {
@@ -339,11 +342,19 @@ public class ChainKnotEntity extends AbstractDecorationEntity {
 
         Entity[] entitySet = holdingEntities.values().toArray(new Entity[0]).clone();
         for (Entity entity : entitySet) {
-            if (entity != null) {
-                if (!this.isAlive() || !entity.isAlive() || entity.getPos().squaredDistanceTo(this.getPos()) > MAX_RANGE * MAX_RANGE) {
-                    this.detachChain(entity, true,  !(entity instanceof PlayerEntity && ((PlayerEntity) entity).isCreative()));
-                    onBreak(null);
+            if (entity == null) continue;
+            if (!this.isAlive() || !entity.isAlive() || entity.getPos().squaredDistanceTo(this.getPos()) > getMaxRange() * getMaxRange()) {
+                if (entity instanceof ChainKnotEntity knot) {
+                    damageLink(false, knot);
+                    continue;
                 }
+
+                boolean drop = true;
+                if(entity instanceof PlayerEntity player) {
+                     drop = !player.isCreative();
+                }
+                this.detachChain(entity, true, drop);
+                onBreak(null);
             }
         }
     }
@@ -458,26 +469,25 @@ public class ChainKnotEntity extends AbstractDecorationEntity {
      * @param dropItem should we drop an item?
      */
     public void detachChain(Entity entity, boolean sendPacket, boolean dropItem) {
-        if (entity != null) {
+        if (entity == null) return;
 
-            this.holdingEntities.remove(entity.getId());
-            if (!this.world.isClient() && dropItem && this.world.getGameRules().getBoolean(GameRules.DO_ENTITY_DROPS)) {
-                Vec3d middle = Helper.middleOf(getPos(), entity.getPos());
-                ItemEntity entity1 = new ItemEntity(world, middle.x, middle.y, middle.z, new ItemStack(Items.CHAIN));
-                entity1.setToDefaultPickupDelay();
-                this.world.spawnEntity(entity1);
-            }
+        this.holdingEntities.remove(entity.getId());
+        if (!this.world.isClient() && dropItem && this.world.getGameRules().getBoolean(GameRules.DO_ENTITY_DROPS)) {
+            Vec3d middle = Helper.middleOf(getPos(), entity.getPos());
+            ItemEntity entity1 = new ItemEntity(world, middle.x, middle.y, middle.z, new ItemStack(Items.CHAIN));
+            entity1.setToDefaultPickupDelay();
+            this.world.spawnEntity(entity1);
+        }
 
-            if (!this.world.isClient() && sendPacket && this.world instanceof ServerWorld) {
-                if (entity instanceof ChainKnotEntity) {
-                    ((ChainKnotEntity) entity).holdersCount--;
-                    if (this.holdersCount <= 0 && getHoldingEntities().isEmpty()) {
-                        this.remove(RemovalReason.DISCARDED);
-                    }
-                }
-                deleteCollision(entity);
-                sendDetachChainPacket(entity.getId());
+        if (!this.world.isClient() && sendPacket && this.world instanceof ServerWorld) {
+            if (entity instanceof ChainKnotEntity) {
+                ((ChainKnotEntity) entity).holdersCount--;
             }
+            if (this.holdersCount <= 0 && getHoldingEntities().isEmpty()) {
+                this.remove(RemovalReason.DISCARDED);
+            }
+            deleteCollision(entity);
+            sendDetachChainPacket(entity.getId());
         }
     }
 
@@ -494,35 +504,64 @@ public class ChainKnotEntity extends AbstractDecorationEntity {
         if (COLLISION_STORAGE.containsKey(entity.getId())) return;
 
         double distance = this.distanceTo(entity);
-        double a = .69 / distance;
-        double v = a;
+        double step = 1.5*Math.sqrt(Math.pow(ModEntityTypes.CHAIN_COLLISION.getWidth(), 2)*2) / distance;
+        double v = step;
+        double centerHoldout = ModEntityTypes.CHAIN_COLLISION.getWidth() / distance;
 
         ArrayList<Integer> entityIdList = new ArrayList<>();
-        double x1, x2, y1, y2, z1, z2;
-        double offset = 0.2D;
-        while (v <= 1 - (a / 2)) {
-            x1 = MathHelper.lerp(v, this.getX(), entity.getX());
-            y1 = this.getY() + Helper.drip2((v * distance), distance, entity.getY() - this.getY()) + offset;
-            z1 = MathHelper.lerp(v, this.getZ(), entity.getZ());
-            x2 = MathHelper.lerp(v, entity.getX(), this.getX());
-            y2 = entity.getY() + Helper.drip2((v * distance), distance, this.getY() - entity.getY()) + offset;
-            z2 = MathHelper.lerp(v, entity.getZ(), this.getZ());
-            ChainCollisionEntity c1 = new ChainCollisionEntity(this.world, x1, y1, z1, this.getId(), entity.getId());
-            ChainCollisionEntity c2 = new ChainCollisionEntity(this.world, x2, y2, z2, this.getId(), entity.getId());
+        while (v < 0.5 - centerHoldout) {
+            Entity collider1 = spawnCollision(false, this, entity, v);
+            if(collider1 != null) entityIdList.add(collider1.getId());
+            Entity collider2 = spawnCollision(true, this, entity, v);
+            if(collider2 != null) entityIdList.add(collider2.getId());
 
-            if (world.spawnEntity(c1)) {
-                entityIdList.add(c1.getId());
-            } else {
-                LOGGER.warn("Tried to summon collision entity for a chain, failed to do so");
-            }
-            if (world.spawnEntity(c2)) {
-                entityIdList.add(c2.getId());
-            } else {
-                LOGGER.warn("Tried to summon collision entity for a chain, failed to do so");
-            }
-            v = v + a;
+            v += step;
         }
+
+        Entity centerCollider = spawnCollision(false,this, entity, 0.5);
+        if(centerCollider != null) entityIdList.add(centerCollider.getId());
+
         this.COLLISION_STORAGE.put(entity.getId(), entityIdList);
+    }
+
+    /**
+     * Spawns a collider at v percent between entity1 and entity2
+     * @param reverse Reverse start and end
+     * @param start the entity at v=0
+     * @param end the entity at v=1
+     * @param v percent of the distance
+     * @return {@link ChainCollisionEntity} or null
+     */
+    @Nullable
+    private Entity spawnCollision(boolean reverse, Entity start, Entity end, double v) {
+        Vec3d startPos = start.getPos().add(start.getLeashOffset());
+        Vec3d endPos = end.getPos().add(end.getLeashOffset());
+
+        Vec3d tmp = endPos;
+        if(reverse) {
+            endPos = startPos;
+            startPos = tmp;
+        }
+
+        Vec3f offset = Helper.getChainOffset(startPos, endPos);
+        startPos = startPos.add(offset.getX(), 0, offset.getZ());
+        endPos = endPos.add(-offset.getX(), 0, -offset.getZ());
+
+        double distance = startPos.distanceTo(endPos);
+
+        double x = MathHelper.lerp(v, startPos.getX(), endPos.getX());
+        double y = startPos.getY() + Helper.drip2((v * distance), distance, endPos.getY() - startPos.getY());
+        double z = MathHelper.lerp(v, startPos.getZ(), endPos.getZ());
+
+        y += -ModEntityTypes.CHAIN_COLLISION.getHeight() + 1/16f;
+
+        ChainCollisionEntity c = new ChainCollisionEntity(this.world, x, y, z, start.getId(), end.getId());
+        if (world.spawnEntity(c)) {
+            return c;
+        } else {
+            LOGGER.warn("Tried to summon collision entity for a chain, failed to do so");
+            return null;
+        }
     }
 
     /**
@@ -694,13 +733,17 @@ public class ChainKnotEntity extends AbstractDecorationEntity {
         return EntitySpawnPacketCreator.create(this, NetworkingPackages.S2C_SPAWN_CHAIN_KNOT_PACKET, extraData);
     }
 
+    public Vec3d getLeashOffset() {
+        return new Vec3d(0, 5/16f, 0);
+    }
+
     /**
-     * Not sure what this does but {@link net.minecraft.entity.decoration.LeashKnotEntity#method_30951(float)} has it.
+     * Not sure what this does but {@link net.minecraft.entity.decoration.LeashKnotEntity#getLeashPos(float)} has it.
      */
     @Environment(EnvType.CLIENT)
     @Override
-    public Vec3d method_30951(float f) {
-        return this.getLerpedPos(f).add(0.0D, 0.2D, 0.0D);
+    public Vec3d getLeashPos(float f) {
+        return this.getLerpedPos(f).add(0.0D, 5/16f, 0.0D);
     }
 
     /**

--- a/src/main/java/com/github/legoatoom/connectiblechains/enitity/ChainKnotEntity.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/enitity/ChainKnotEntity.java
@@ -70,6 +70,12 @@ public class ChainKnotEntity extends AbstractDecorationEntity {
     private static final double VISIBLE_RANGE = 2048.0D;
 
     /**
+     * The x/z distance between {@link ChainCollisionEntity ChainCollisionEntities}.
+     * A value of 1 means they are "shoulder to shoulder"
+     */
+    private static final float COLLIDER_SPACING = 1.5f;
+
+    /**
      * A map that holds a list of entity ids. These entities should be {@link ChainCollisionEntity ChainCollisionEntities}
      * The key is the entity id of the ChainKnot that this is connected to.
      */
@@ -504,7 +510,7 @@ public class ChainKnotEntity extends AbstractDecorationEntity {
         if (COLLISION_STORAGE.containsKey(entity.getId())) return;
 
         double distance = this.distanceTo(entity);
-        double step = 1.5*Math.sqrt(Math.pow(ModEntityTypes.CHAIN_COLLISION.getWidth(), 2)*2) / distance;
+        double step = COLLIDER_SPACING*Math.sqrt(Math.pow(ModEntityTypes.CHAIN_COLLISION.getWidth(), 2)*2) / distance;
         double v = step;
         double centerHoldout = ModEntityTypes.CHAIN_COLLISION.getWidth() / distance;
 

--- a/src/main/java/com/github/legoatoom/connectiblechains/enitity/ModEntityTypes.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/enitity/ModEntityTypes.java
@@ -42,7 +42,7 @@ public class ModEntityTypes {
                 FabricEntityTypeBuilder.create(SpawnGroup.MISC,
                         (EntityType.EntityFactory<ChainKnotEntity>) ChainKnotEntity::new)
                         .trackRangeBlocks(10).trackedUpdateRate(Integer.MAX_VALUE).forceTrackedVelocityUpdates(false)
-                        .dimensions(EntityDimensions.fixed(0.5F, 0.5F))
+                        .dimensions(EntityDimensions.fixed(6/16f, 0.5F))
                         .spawnableFarFromPlayer()
                         .fireImmune()
                         .build()
@@ -52,7 +52,8 @@ public class ModEntityTypes {
                 FabricEntityTypeBuilder.create(SpawnGroup.MISC,
                         (EntityType.EntityFactory<ChainCollisionEntity>) ChainCollisionEntity::new)
                         .trackRangeBlocks(10).trackedUpdateRate(Integer.MAX_VALUE).forceTrackedVelocityUpdates(false)
-                        .dimensions(EntityDimensions.changing(0.3F, 0.3F))
+                        // 4/16 is the width of a fence
+                        .dimensions(EntityDimensions.fixed(4/16f, 0.3F))
                         .disableSaving()
                         .disableSummon()
                         .fireImmune()

--- a/src/main/java/com/github/legoatoom/connectiblechains/mixin/server/world/ThreadedAnvilChunkStorageMixin.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/mixin/server/world/ThreadedAnvilChunkStorageMixin.java
@@ -27,9 +27,11 @@ import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.entity.Entity;
 import net.minecraft.network.Packet;
 import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.packet.s2c.play.ChunkDataS2CPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ThreadedAnvilChunkStorage;
 import net.minecraft.world.chunk.WorldChunk;
+import org.apache.commons.lang3.mutable.MutableObject;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -57,7 +59,7 @@ public abstract class ThreadedAnvilChunkStorageMixin {
             method = "sendChunkDataPackets",
             at = @At(value = "TAIL")
     )
-    private void sendAttachChainPackets(ServerPlayerEntity player, Packet<?>[] packets, WorldChunk chunk, CallbackInfo ci) {
+    private void sendAttachChainPackets(ServerPlayerEntity player, MutableObject<ChunkDataS2CPacket> cachedDataPacket, WorldChunk chunk, CallbackInfo ci) {
         ObjectIterator<ThreadedAnvilChunkStorage.EntityTracker> var6 = this.entityTrackers.values().iterator();
         List<ChainKnotEntity> list = Lists.newArrayList();
 

--- a/src/main/java/com/github/legoatoom/connectiblechains/mixin/server/world/ThreadedAnvilChunkStorageMixin.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/mixin/server/world/ThreadedAnvilChunkStorageMixin.java
@@ -25,7 +25,6 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.objects.ObjectIterator;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.entity.Entity;
-import net.minecraft.network.Packet;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.packet.s2c.play.ChunkDataS2CPacket;
 import net.minecraft.server.network.ServerPlayerEntity;

--- a/src/main/java/com/github/legoatoom/connectiblechains/util/Helper.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/util/Helper.java
@@ -20,6 +20,7 @@ package com.github.legoatoom.connectiblechains.util;
 import com.github.legoatoom.connectiblechains.ConnectibleChains;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.Vec3f;
 
 public class Helper {
 
@@ -29,17 +30,45 @@ public class Helper {
 
     @Deprecated
     public static double drip(double x, double d) {
-        double c = ConnectibleChains.config.getChainHangAmount();
+        double c = ConnectibleChains.runtimeConfig.getChainHangAmount();
         double b = -c / d;
         double a = c / (d * d);
         return (a * (x * x) + b * x);
     }
 
+    /**
+     * For geogebra:
+     * a = 9
+     * h = 0
+     * d = 5
+     * p1 = a * asinh( (h / (2*a)) * 1 / sinh(d / (2*a)) )
+     * p2 = -a * cosh( (2*p1 - d) / (2*a) )
+     * f(x) = p2 + a * cosh( (2*x + 2*p1 - d) / (2*a) )
+     * @param x from 0 to d
+     * @param d length of the chain
+     * @param h height at x=d
+     * @return y
+     */
     public static double drip2(double x, double d, double h) {
-        double a = ConnectibleChains.config.getChainHangAmount();
+        double a = ConnectibleChains.runtimeConfig.getChainHangAmount();
         double p1 = a * asinh((h / (2D * a)) * (1D / Math.sinh(d / (2D * a))));
         double p2 = -a * Math.cosh((2D * p1 - d) / (2D * a));
         return p2 + a * Math.cosh((((2D * x) + (2D * p1)) - d) / (2D * a));
+    }
+
+    /**
+     * Derivative of drip2
+     * For geogebra:
+     * f'(x) = sinh( (2*x + 2*p1 - d) / (2*a) )
+     * @param x from 0 to d
+     * @param d length of the chain
+     * @param h height at x=d
+     * @return gradient at x
+     */
+    public static double drip2prime(double x, double d, double h) {
+        double a = ConnectibleChains.runtimeConfig.getChainHangAmount();
+        double p1 = a * asinh((h / (2D * a)) * (1D / Math.sinh(d / (2D * a))));
+        return Math.sinh( (2*x + 2*p1 - d) / (2*a) );
     }
 
     private static double asinh(double x) {
@@ -51,5 +80,33 @@ public class Helper {
         double y = (a.getY() - b.getY()) / 2d + b.getY();
         double z = (a.getZ() - b.getZ()) / 2d + b.getZ();
         return new Vec3d(x, y, z);
+    }
+
+    public static float distanceBetween(Vec3f a, Vec3f b) {
+        float dx = a.getX() - b.getX();
+        float dy = a.getY() - b.getY();
+        float dz = a.getZ() - b.getZ();
+        return (float) Math.sqrt(dx*dx + dy*dy + dz*dz);
+    }
+
+    public static float lengthOf(Vec3f v) {
+        float x = v.getX();
+        float y = v.getY();
+        float z = v.getZ();
+        return (float) Math.sqrt(x*x + y*y + z*z);
+    }
+
+    /**
+     * Get the x/z offset from a chain to a fence
+     * @param start fence pos
+     * @param end fence pos
+     * @return the x/z offset
+     */
+    public static Vec3f getChainOffset(Vec3d start, Vec3d end) {
+        Vec3f offset = new Vec3f(end.subtract(start));
+        offset.set(offset.getX(), 0, offset.getZ());
+        offset.normalize();
+        offset.scale(2/16f);
+        return offset;
     }
 }

--- a/src/main/java/com/github/legoatoom/connectiblechains/util/NetworkingPackages.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/util/NetworkingPackages.java
@@ -27,5 +27,6 @@ public class NetworkingPackages {
     public static final Identifier S2C_MULTI_CHAIN_ATTACH_PACKET_ID = Helper.identifier("s2c_multi_chain_attach_packet_id");
     public static final Identifier S2C_SPAWN_CHAIN_COLLISION_PACKET = Helper.identifier("s2c_spawn_chain_collision_packet_id");
     public static final Identifier S2C_SPAWN_CHAIN_KNOT_PACKET = Helper.identifier("s2c_spawn_chain_knot_packet_id");
+    public static final Identifier S2C_CONFIG_SYNC_PACKET = Helper.identifier("s2c_config_sync_packet_id");
 
 }

--- a/src/main/resources/assets/connectiblechains/lang/en_us.json
+++ b/src/main/resources/assets/connectiblechains/lang/en_us.json
@@ -3,11 +3,13 @@
   "entity.connectiblechains.chain_collision" : "Chain Collision",
   "text.autoconfig.connectiblechains.option.chainHangAmount" : "Chain Drip",
   "text.autoconfig.connectiblechains.option.maxChainRange" : "Max Chain Distance",
-  "text.autoconfig.connectiblechains.option.chainHangAmount.@Tooltip[0]" : "Effects how much the Chain Hangs.",
-  "text.autoconfig.connectiblechains.option.chainHangAmount.@Tooltip[1]" : "Only Client Side visually on servers",
-  "text.autoconfig.connectiblechains.option.chainHangAmount.@Tooltip[2]" : "In SinglePlayer, collision will only update on new chains.",
+  "text.autoconfig.connectiblechains.option.quality" : "Chain Quality",
+  "text.autoconfig.connectiblechains.option.chainHangAmount.@Tooltip[0]" : "Effects how much the chain hangs.",
+  "text.autoconfig.connectiblechains.option.chainHangAmount.@Tooltip[1]" : "Collision will update on new chains or world loading.",
+  "text.autoconfig.connectiblechains.option.chainHangAmount.@Tooltip[2]" : "Has no effect in multiplayer.",
   "text.autoconfig.connectiblechains.option.maxChainRange.@Tooltip[0]" : "Effects how long a chain can be.",
-  "text.autoconfig.connectiblechains.option.maxChainRange.@Tooltip[1]" : "This settings only effects client side.",
-  "text.autoconfig.connectiblechains.option.maxChainRange.@Tooltip[2]" : "Warning: Increasing the length beyond 7 may cause unexpected rendering behaviour!",
+  "text.autoconfig.connectiblechains.option.maxChainRange.@Tooltip[1]" : "§nWarning§r: Long chains can sometimes become invisible!",
+  "text.autoconfig.connectiblechains.option.maxChainRange.@Tooltip[2]" : "Has no effect in multiplayer.",
+  "text.autoconfig.connectiblechains.option.quality.@Tooltip" : "Effects the visual quality the chain.",
   "text.autoconfig.connectiblechains.title": "Connectible Chains Configs"
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -36,7 +36,7 @@
   "depends": {
     "fabricloader": ">=0.11.3",
     "fabric": "*",
-    "minecraft": "1.17.x",
+    "minecraft": "1.18.x",
     "cloth-config2": ">=5.0.34"
   },
   "breaks": {


### PR DESCRIPTION
- Fixed https://github.com/legoatoom/ConnectibleChains/issues/7
- Improved collider placement
- Fixed Max Chain Distance only taking effect after restart
- Fixed left over knots when a chain breaks because it's too long
- Improved lang file a little
- Sync chain config to client (I've copied the code form my mod [boat-step-up](https://github.com/Qendolin/boat-step-up))

Replaced chain line renderer fixing many issues
- Fixed UV stretching (In some cases the pixels still aren't acute trapezoids but obtuse)
- Fixed hard coded texture
- Fixed very high poly count
- Added adjustable quality setting
- Fixed pixel gaps between polygons
- Added model caching
- Added debug rendering
- Improved lighting
- Fixed incorrect chain position on first frames after a new connection

| Old                | New                 |
|----------------|-----------------|
| ![collider old] | ![collider new] |
| ![chain old]    | ![chain new]    |


[collider old]: https://user-images.githubusercontent.com/32160662/149204386-96a82e78-bd8c-41c8-a190-2c0e2b2632fd.png
[collider new]: https://user-images.githubusercontent.com/32160662/149204434-58c02e98-feb6-4a88-8cb0-0eb6120acccd.png
[chain old]: https://user-images.githubusercontent.com/32160662/149204906-79d7836a-e1f6-4d74-92d0-42f4b0df171f.png
[chain new]: https://user-images.githubusercontent.com/32160662/149204977-0af3db59-85b0-4041-9a09-e747ddaafe8c.png



