### PR TITLE
Adjusted Tooltip count for maxChainRange

### DIFF
--- a/src/main/java/com/github/legoatoom/connectiblechains/config/ModConfig.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/config/ModConfig.java
@@ -40,7 +40,7 @@ public class ModConfig implements ConfigData {
     @ConfigEntry.Gui.Tooltip(count = 3)
     private float chainHangAmount = 7.0F;
     @ConfigEntry.BoundedDiscrete(max = 32)
-    @ConfigEntry.Gui.Tooltip(count = 3)
+    @ConfigEntry.Gui.Tooltip(count = 2)
     private int maxChainRange = 7;
     @ConfigEntry.BoundedDiscrete(min = 1, max = 8)
     @ConfigEntry.Gui.Tooltip()


### PR DESCRIPTION
Changes the Tooltip count from `3` to `2` for `maxChainRange` so that `text.autoconfig.connectiblechains.option.maxChainRange.@Tooltip[2]` isn't visible when using the in-game config.