### PR TITLE
Fix Knot Behavior, Interaction Safety, and Cleanup Logic

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Time is following the [Holocene Calendar](https://en.wikipedia.org/wiki/Holocene_calendar).
 
+## [2.5.8] - 12026-01-07
+
+* Add logic to automatically discard empty knots.
+* Knots now check for a valid attachment block and are discarded immediately if the supporting fence or block is removed.
+* Add ability to punch knots to break them.
+* Fix using shears to break knots not reducing its durability.
+* Prevent mixing and matching different catenary types on a single knot.
+* Fix collision entities persisting on servers.
+
 ## [2.5.7] - 12026-01-07
 
 - Support Beautify ropes [#94](https://github.com/legoatoom/ConnectibleChains/issues/94)

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,8 @@ Time is following the [Holocene Calendar](https://en.wikipedia.org/wiki/Holocene
 * Prevent mixing and matching different catenary types on a single knot.
 * Fix collision entities persisting on servers.
 * Add additional check for knots across unloaded chunks. [#73](https://github.com/legoatoom/ConnectibleChains/issues/73)
+* Optimized chain rendering performance and fixed a potential memory leak in the model cache.
+* Prevent chains from snapping when attached to entities in unloaded chunks.
 
 ## [2.5.7] - 12026-01-07
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,15 +8,16 @@ Time is following the [Holocene Calendar](https://en.wikipedia.org/wiki/Holocene
 
 ## [2.5.8] - 12026-01-07
 
-* Add logic to automatically discard empty knots.
-* Knots now check for a valid attachment block and are discarded immediately if the supporting fence or block is removed.
-* Add ability to punch knots to break them.
-* Fix using shears to break knots not reducing its durability.
-* Prevent mixing and matching different catenary types on a single knot.
-* Fix collision entities persisting on servers.
-* Add additional check for knots across unloaded chunks. [#73](https://github.com/legoatoom/ConnectibleChains/issues/73)
-* Optimized chain rendering performance and fixed a potential memory leak in the model cache.
-* Prevent chains from snapping when attached to entities in unloaded chunks.
+- Add logic to automatically discard empty knots.
+- Knots now check for a valid attachment block and are discarded immediately if the supporting fence or block is removed.
+- Add ability to punch knots to break them.
+- Fix using shears to break knots not reducing its durability.
+- Prevent mixing and matching different catenary types on a single knot.
+- Fix collision entities persisting on servers.
+- Add additional check for knots across unloaded chunks. [#73](https://github.com/legoatoom/ConnectibleChains/issues/73)
+- Optimized chain rendering performance and fixed a potential memory leak in the model cache.
+- Prevent chains from snapping when attached to entities in unloaded chunks.
+- Add config option to disable chain collision.
 
 ## [2.5.7] - 12026-01-07
 

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ Time is following the [Holocene Calendar](https://en.wikipedia.org/wiki/Holocene
 * Fix using shears to break knots not reducing its durability.
 * Prevent mixing and matching different catenary types on a single knot.
 * Fix collision entities persisting on servers.
+* Add additional check for knots across unloaded chunks. [#73](https://github.com/legoatoom/ConnectibleChains/issues/73)
 
 ## [2.5.7] - 12026-01-07
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ loader_version=0.16.14
 # Fabric API
 fabric_version=0.92.6+1.20.1
 # Mod Properties
-mod_version=2.5.7
+mod_version=2.5.8
 maven_group=com.github.legoatoom.connectiblechains
 archives_base_name=connectiblechains
 cloth_version=11.1.136

--- a/src/main/java/com/github/legoatoom/connectiblechains/config/ModConfig.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/config/ModConfig.java
@@ -43,6 +43,10 @@ public class ModConfig implements ConfigData {
 
     @ConfigEntry.Gui.Tooltip()
     private boolean showToolTip = true;
+
+    @ConfigEntry.Gui.Tooltip()
+    private boolean collisionsEnabled = true;
+
     public float getChainHangAmount() {
         return chainHangAmount;
     }
@@ -74,6 +78,14 @@ public class ModConfig implements ConfigData {
         return IS_DEBUG_ENV && MinecraftClient.getInstance().options.debugEnabled;
     }
 
+    public boolean isCollisionsEnabled() {
+        return collisionsEnabled;
+    }
+
+    public void setCollisionsEnabled(boolean collisionsEnabled) {
+        this.collisionsEnabled = collisionsEnabled;
+    }
+
     public void syncToClients(MinecraftServer server) {
         for (ServerPlayerEntity player : PlayerLookup.all(server)) {
             syncToClient(player);
@@ -81,14 +93,16 @@ public class ModConfig implements ConfigData {
     }
 
     public void syncToClient(ServerPlayerEntity player) {
-        ServerPlayNetworking.send(player, new ConfigSyncPayload(chainHangAmount, maxChainRange));
+        ServerPlayNetworking.send(player, new ConfigSyncPayload(chainHangAmount, maxChainRange, collisionsEnabled));
     }
 
+    // [MODIFY THIS METHOD]
     public ModConfig copyFrom(ModConfig config) {
         this.chainHangAmount = config.chainHangAmount;
         this.maxChainRange = config.maxChainRange;
         this.quality = config.quality;
         this.showToolTip = config.showToolTip;
+        this.collisionsEnabled = config.collisionsEnabled;
         return this;
     }
 

--- a/src/main/java/com/github/legoatoom/connectiblechains/entity/ChainCollisionEntity.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/entity/ChainCollisionEntity.java
@@ -85,6 +85,12 @@ public class ChainCollisionEntity extends Entity implements ChainLinkEntity {
         if (chainedEntity.getWorld().isClient()) return;
 
         ServerWorld serverWorld = (ServerWorld) chainedEntity.getWorld();
+
+        if (!ConnectibleChains.runtimeConfig.isCollisionsEnabled()) {
+            destroyCollision(serverWorld, chainData);
+            return;
+        }
+
         chainData.collisionStorage.removeIf(id -> serverWorld.getEntityById(id) == null);
 
         if (!chainData.collisionStorage.isEmpty()) return;

--- a/src/main/java/com/github/legoatoom/connectiblechains/entity/ChainCollisionEntity.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/entity/ChainCollisionEntity.java
@@ -205,11 +205,26 @@ public class ChainCollisionEntity extends Entity implements ChainLinkEntity {
     }
 
     @Override
+    public void tick() {
+        super.tick();
+        if (getWorld().isClient) return;
+
+        if (this.link == null || !this.link.isAlive()) {
+            this.discard();
+        }
+    }
+
+    @Override
     protected void readCustomDataFromNbt(NbtCompound nbt) {
     }
 
     @Override
     protected void writeCustomDataToNbt(NbtCompound nbt) {
+    }
+
+    @Override
+    public boolean shouldSave() {
+        return false;
     }
 
     /**
@@ -240,7 +255,11 @@ public class ChainCollisionEntity extends Entity implements ChainLinkEntity {
         if (getWorld().isClient) return false;
 
         // SEVER-SIDE //
-        assert getLink() != null;
+        if (getLink() == null) {
+            this.discard();
+            return false;
+        }
+
         ActionResult result = onDamageFrom(source, getSourceBlockSoundGroup(getLinkSourceItem()).getHitSound());
 
         if (!result.isAccepted()) {
@@ -266,8 +285,7 @@ public class ChainCollisionEntity extends Entity implements ChainLinkEntity {
     @Override
     public ActionResult interact(PlayerEntity player, Hand hand) {
         if (player.getStackInHand(hand).isIn(ConventionalItemTags.SHEARS)) {
-
-            return ActionResult.SUCCESS;
+            return ActionResult.PASS;
         }
         return ActionResult.PASS;
     }

--- a/src/main/java/com/github/legoatoom/connectiblechains/entity/ChainKnotEntity.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/entity/ChainKnotEntity.java
@@ -121,6 +121,10 @@ public class ChainKnotEntity extends AbstractDecorationEntity implements Chainab
 
     @Override
     public void tick() {
+        if (!this.getWorld().isClient && !this.canStayAttached()) {
+            this.discard();
+            this.onBreak(null);
+        }
         super.tick();
         if (this.getWorld() instanceof ServerWorld serverWorld) {
             Chainable.tickChain(serverWorld, this);
@@ -143,6 +147,8 @@ public class ChainKnotEntity extends AbstractDecorationEntity implements Chainab
 
             // Client handle attach.
             if (handStack.isIn(ModTagRegistry.CATENARY_ITEMS)) {
+                if (handStack.getItem() != this.sourceItem) return ActionResult.PASS;
+
                 if (!player.isCreative()) {
                     handStack.decrement(1);
                 }
@@ -165,6 +171,9 @@ public class ChainKnotEntity extends AbstractDecorationEntity implements Chainab
                 // TODO: Kinda inefficient, perhaps return a list of pairs? Chainable+ChainData.
                 ChainData chainData = chainable.getChainData(player);
                 if (chainData == null || !chainable.canAttachTo(this)) continue;
+
+                if (chainData.sourceItem != this.sourceItem) continue;
+
                 chainable.attachChain(new ChainData(this, chainData.sourceItem), player, true);
                 hasConnectedFromPlayer = true;
             }
@@ -194,6 +203,8 @@ public class ChainKnotEntity extends AbstractDecorationEntity implements Chainab
 
             // CASE: Player interacts with knot that they are currently NOT attached to. Make a new connection.
             if (handStack.isIn(ModTagRegistry.CATENARY_ITEMS)) {
+                if (handStack.getItem() != this.sourceItem) return ActionResult.PASS;
+
                 onPlace();
                 attachChain(new ChainData(player, handStack.getItem()), null, true);
                 if (!player.isCreative()) {

--- a/src/main/java/com/github/legoatoom/connectiblechains/entity/ChainLinkEntity.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/entity/ChainLinkEntity.java
@@ -21,6 +21,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.registry.tag.DamageTypeTags;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
 
 /**
  * ChainLinkEntity implements common functionality between {@link ChainCollisionEntity} and {@link ChainKnotEntity}.
@@ -41,8 +42,12 @@ public interface ChainLinkEntity {
 
         if (source.getAttacker() instanceof PlayerEntity player) {
             if (player.getMainHandStack().isIn(ConventionalItemTags.SHEARS)) {
+                if (!player.isCreative()) {
+                    player.getMainHandStack().damage(1, player, (p) -> p.sendToolBreakStatus(Hand.MAIN_HAND));
+                }
                 return ActionResult.SUCCESS;
             }
+            return ActionResult.SUCCESS;
         }
 
         if (!source.isIn(DamageTypeTags.IS_PROJECTILE)) {

--- a/src/main/java/com/github/legoatoom/connectiblechains/entity/Chainable.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/entity/Chainable.java
@@ -98,7 +98,6 @@ public interface Chainable {
                         ChainData newChainData = new ChainData(chainHolder, chainData.sourceItem);
                         entity.replaceChainData(chainData, null);
                         attachChain(entity, newChainData, null, true); // TODO: Do it in one bulk action instead of separate.
-                        continue;
                     }
                 } else if (optionalBlockPos.isPresent()) {
                     BlockPos targetPos = entity.getDecorationBlockPos().add(optionalBlockPos.get());
@@ -112,15 +111,9 @@ public interface Chainable {
                         ChainData newChainData = new ChainData(chainHolder, chainData.sourceItem);
                         entity.replaceChainData(chainData, null);
                         attachChain(entity, newChainData, null, true);
-                        continue;
                     }
                 }
 
-                if (entity.age > 100) {
-                    ConnectibleChains.LOGGER.debug("Dropping chain connection as we have not been able to find chainholder for {}", chainData);
-                    entity.dropItem(chainData.sourceItem);
-                    entity.replaceChainData(chainData, null);
-                }
             }
         }
     }
@@ -219,6 +212,10 @@ public interface Chainable {
                     float distanceTo = entity.distanceTo(chainHolder);
                     if (!entity.beforeChainTick(chainHolder, distanceTo)) {
                         continue;
+                    }
+
+                    if (chainHolder instanceof Chainable) {
+                        ChainCollisionEntity.createCollision(entity, chainData);
                     }
 
                     if (distanceTo > getMaxChainLength()) {
@@ -422,7 +419,7 @@ public interface Chainable {
 
     Vec3d getChainPos(float delta);
 
-    public static final class ChainData {
+    final class ChainData {
         /**
          * Boolean to check if the chain link is already dead
          */

--- a/src/main/java/com/github/legoatoom/connectiblechains/entity/Chainable.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/entity/Chainable.java
@@ -91,6 +91,7 @@ public interface Chainable {
             if (chainData.unresolvedChainData != null) {
                 Optional<UUID> optionalUUID = chainData.unresolvedChainData.left();
                 Optional<BlockPos> optionalBlockPos = chainData.unresolvedChainData.right();
+
                 if (optionalUUID.isPresent()) {
                     Entity chainHolder = serverWorld.getEntity(optionalUUID.get());
                     if (chainHolder != null) {
@@ -100,7 +101,13 @@ public interface Chainable {
                         continue;
                     }
                 } else if (optionalBlockPos.isPresent()) {
-                    ChainKnotEntity chainHolder = ChainKnotEntity.getOrNull(serverWorld, entity.getDecorationBlockPos().add(optionalBlockPos.get()));
+                    BlockPos targetPos = entity.getDecorationBlockPos().add(optionalBlockPos.get());
+
+                    if (!serverWorld.isChunkLoaded(targetPos)) {
+                        continue;
+                    }
+
+                    ChainKnotEntity chainHolder = ChainKnotEntity.getOrNull(serverWorld, targetPos);
                     if (chainHolder != null) {
                         ChainData newChainData = new ChainData(chainHolder, chainData.sourceItem);
                         entity.replaceChainData(chainData, null);

--- a/src/main/java/com/github/legoatoom/connectiblechains/item/ChainItemCallbacks.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/item/ChainItemCallbacks.java
@@ -75,6 +75,8 @@ public class ChainItemCallbacks {
                 if (world instanceof ServerWorld serverWorld) {
                     ChainKnotEntity knot = ChainKnotEntity.getOrCreate(serverWorld, blockPos, stack.getItem());
 
+                    if (knot.getSourceItem() != stack.getItem()) return ActionResult.PASS;
+
                     return knot.interact(player, hand);
                 }
                 return ActionResult.SUCCESS;
@@ -102,6 +104,8 @@ public class ChainItemCallbacks {
                 chainKnotEntity = ChainKnotEntity.getOrCreate(world, pos, chainable.getSourceItem());
                 chainKnotEntity.onPlace();
             }
+
+            if (chainable.getSourceItem() != chainKnotEntity.getSourceItem()) continue;
 
             if (chainable.canAttachTo(chainKnotEntity)) {
                 Chainable.ChainData chainData = chainable.getChainData(player);

--- a/src/main/java/com/github/legoatoom/connectiblechains/networking/packet/ConfigSyncPayload.java
+++ b/src/main/java/com/github/legoatoom/connectiblechains/networking/packet/ConfigSyncPayload.java
@@ -26,17 +26,18 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.network.PacketByteBuf;
 
-public record ConfigSyncPayload(float chainHangAmount, int maxChainRange) implements FabricPacket {
+public record ConfigSyncPayload(float chainHangAmount, int maxChainRange, boolean collisionsEnabled) implements FabricPacket {
     public static final PacketType<ConfigSyncPayload> TYPE = PacketType.create(Helper.identifier("s2c_config_sync_packet_id"), ConfigSyncPayload::new);
 
     public ConfigSyncPayload(PacketByteBuf buf) {
-        this(buf.readFloat(), buf.readInt());
+        this(buf.readFloat(), buf.readInt(), buf.readBoolean());
     }
 
     @Override
     public void write(PacketByteBuf buf) {
         buf.writeFloat(chainHangAmount);
         buf.writeInt(maxChainRange);
+        buf.writeBoolean(collisionsEnabled);
     }
 
     @Override
@@ -54,6 +55,7 @@ public record ConfigSyncPayload(float chainHangAmount, int maxChainRange) implem
             ConnectibleChains.LOGGER.info("Received {} config from server", ConnectibleChains.MODID);
             ConnectibleChains.runtimeConfig.setChainHangAmount(this.chainHangAmount);
             ConnectibleChains.runtimeConfig.setMaxChainRange(this.maxChainRange);
+            ConnectibleChains.runtimeConfig.setCollisionsEnabled(this.collisionsEnabled);
         } catch (Exception e) {
             ConnectibleChains.LOGGER.error("Could not deserialize config: ", e);
         }

--- a/src/main/resources/assets/connectiblechains/lang/en_us.json
+++ b/src/main/resources/assets/connectiblechains/lang/en_us.json
@@ -11,6 +11,8 @@
   "text.autoconfig.connectiblechains.option.chainHangAmount.@Tooltip[2]" : "Collision will update on new chains or world loading.",
   "text.autoconfig.connectiblechains.option.showToolTip" : "Show Catenary Compatibility Tooltip",
   "text.autoconfig.connectiblechains.option.showToolTip.@Tooltip" : "Show tooltip over chain items that are compatible with this mod.",
+  "text.autoconfig.connectiblechains.option.collisionsEnabled": "Enable Chain Collisions",
+  "text.autoconfig.connectiblechains.option.collisionsEnabled.@Tooltip": "If disabled, chains will not have a collision box and entities can pass through them.",
 
   "text.autoconfig.connectiblechains.option.maxChainRange.@Tooltip[0]" : "Effects how long a chain can be.",
   "text.autoconfig.connectiblechains.option.maxChainRange.@Tooltip[1]" : "§nWarning§r: Long chains can sometimes become invisible!",


### PR DESCRIPTION
* Added logic to automatically discard empty knots, so if a knot has no incoming or outgoing connections (e.g., when the other end of a chain is broken), it will now instantly disappear
* Knots now check for a valid attachment block and are discarded immediately if the supporting fence or block is removed
* Players can now punch knots to break them
* Using shears to break knots now reduces its durability
* Knots now enforce type checking, so you can't mix and match different catenary types on a single knot
* Fixed issue where collision entities would persist on servers
* Added additional check for chunk load safety (possibly fixes #73?)
* Added config option to disable chain collision

I'm open to making any changes if you'd like, as some of these things could be considered major behaviour changes. Let me know!